### PR TITLE
Add hard-coded link to Board Minutes Summary Log

### DIFF
--- a/src/templates/documents.html
+++ b/src/templates/documents.html
@@ -10,6 +10,15 @@
       Change made successfully!  It'll show up here in a few minutes.
     </div>
   {% endif %}
+  <div class="documents-section">
+    <h3>Minutes Summary Log</h3>
+    <div>
+      <a href="https://docs.google.com/spreadsheets/d/1EbmqG-bOzBaa43QUU_3907myez7GzITqDL4etvvrPvM/edit#gid=0"
+         target="_blank">
+        CubingUSA Board Minutes Summary Log
+      </a>
+    </div>
+  </div>
   {% for section, documents in documents_by_section %}
     <div class="documents-section">
       <h3>{{ section }}</h3>


### PR DESCRIPTION
Add a hard-coded link to the Board Minutes Summary Log spreadsheet