### PR TITLE
Add teams and team members to who page

### DIFF
--- a/src/templates/about_who.html
+++ b/src/templates/about_who.html
@@ -83,8 +83,5 @@
   <hr>
   <h3>Software Team</h3>
   <p>Jeremy Fleischman, Caleb Hoover, James LaChance, Jim Mertens, Tim Reynolds</p>
-  <hr>
-  <h3>Equipment Team</h3>
-  <p>James Hildreth (Equipment Officer), Tim Reynolds</p>
   <script src="/static/js/about_who.js" type="application/javascript"></script>
 {% endblock %}

--- a/src/templates/about_who.html
+++ b/src/templates/about_who.html
@@ -77,5 +77,14 @@
       <strong><a href="{{ c.wca_profile('2012LUKE01') }}" target="_blank">Kenneth Lu</a></strong> has been a Director of CubingUSA since its inception. Ever since he helped to run an Autonomous Robot Design Competition in college, Kenneth has been looking for another competition to help organize. He shot a video of Nationals 2012 and joined the Nationals Organizer team in 2015. If you have ever emailed CubingUSA, you probably received a reply from Kenneth!
     {% endcall %}
   </div>
+  <hr>
+  <h3>Nationals Organizers Team</h3>
+  <p>Board of Directors, plus: Nathan Dwyer, Calvin Nielson, Tim Reynolds, and Walker Welch</p>
+  <hr>
+  <h3>Software Team</h3>
+  <p>Jeremy Fleischman, Caleb Hoover, James LaChance, Jim Mertens, Tim Reynolds</p>
+  <hr>
+  <h3>Equipment Team</h3>
+  <p>James Hildreth (Equipment Officer), Tim Reynolds</p>
   <script src="/static/js/about_who.js" type="application/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
TODO: Could probably be better styled?

Didn't bother listing the advisory committees; will probably only do that if we add external people again.