### PR TITLE
Reorder index links

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -53,16 +53,16 @@
           </div>
           <ul class="list-group list-group-flush">
             <li class="list-group-item">
+              <a href="https://www.worldcubeassociation.org/competitions?region=USA" target="_blank">Upcoming US Competitions</a>
+            </li>
+            <li class="list-group-item">
+              <a href="http://cubecomps.com" target="_blank">Cubecomps Live Results</a>
+            </li>
+            <li class="list-group-item">
               <a href="{{ c.uri_for('state_rankings') }}">State Rankings</a>
             </li>
             <li class="list-group-item">
               <a href="https://worldcubeassociation.org" target="_blank">World Cube Association</a>
-            </li>
-            <li class="list-group-item">
-              <a href="https://www.worldcubeassociation.org/competitions?region=USA" target="_blank">Upcoming US Competitions</a>
-            </li>
-            <li class="list-group-item">
-              <a href="http://cubecomps.com" target="_blank">Cubecomps live results</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Put Upcoming US Competitions first, followed by Cubecomps, prioritizing them above state rankings and WCA link.