### PR TITLE
Modify the OAuth flow to use a single redirect_uri.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -14,12 +14,14 @@ from src.handlers.login import LoginHandler
 from src.handlers.login import LoginCallbackHandler
 from src.handlers.login import LogoutHandler
 from src.handlers.oauth import AuthenticateHandler
+from src.handlers.oauth import OAuthCallbackHandler
 from src.models.user import Roles
 
 app = webapp2.WSGIApplication([
   webapp2.Route('/', handler=BasicHandler('admin/index.html',
                                           permitted_roles=Roles.AdminRoles())),
   webapp2.Route('/authenticate', handler=AuthenticateHandler),
+  webapp2.Route('/oauth_callback', handler=OAuthCallbackHandler),
   webapp2.Route('/copy_user_states', handler=CopyUserStatesHandler),
   webapp2.Route('/login', handler=LoginHandler, name='login'),
   webapp2.Route('/login_callback', handler=LoginCallbackHandler, name='login_callback'),

--- a/cubingusa.py
+++ b/cubingusa.py
@@ -18,12 +18,14 @@ from src.handlers.login import LoginHandler
 from src.handlers.login import LoginCallbackHandler
 from src.handlers.login import LogoutHandler
 from src.handlers.oauth import AuthenticateHandler
+from src.handlers.oauth import OAuthCallbackHandler
 from src.models.app_settings import AppSettings
 from src.models.user import Roles
 
 app = webapp2.WSGIApplication([
   webapp2.Route('/', handler=BasicHandler('index.html'), name='home'),
   webapp2.Route('/authenticate', handler=AuthenticateHandler),
+  webapp2.Route('/oauth_callback', handler=OAuthCallbackHandler),
   webapp2.Route('/login', handler=LoginHandler, name='login'),
   webapp2.Route('/login_callback', handler=LoginCallbackHandler, name='login_callback'),
   webapp2.Route('/logout', handler=LogoutHandler, name='logout'),

--- a/src/templates/admin/app_settings.html
+++ b/src/templates/admin/app_settings.html
@@ -36,8 +36,8 @@
       (Required) For dev apps, you should create two OAuth applications <a href="https://www.worldcubeassociation.org/oauth/applications" target="_blank">here</a>.  You can set the callback URL to:
       <pre>
 urn:ietf:wg:oauth:2.0:oob
-http://localhost:8080/login_callback
-http://localhost:8081/login_callback
+http://localhost:8080/oauth_callback
+http://localhost:8081/oauth_callback
       </pre>
       For the first one, you will need scopes "public email".  For the second one, you will need scopes "public email manage_competitions".  The prod keys are currently held by Tim Reynolds <a href="https://www.worldcubeassociation.org/oauth/applications/122" target="_blank">here</a> and <a href="https://www.worldcubeassociation.org/oauth/applications/168" target="_blank">here</a>.
     </p>


### PR DESCRIPTION
All OAuth callbacks go through /oauth_callback, and are then forwarded onto the actual callback URL.  This prevents needing to whitelist every URI which needs WCA OAuth tokens.

For staging, use /oauth_callback on cubingusa.org.  This is because we will have multiple hosts on staging, and the alternative is whitelisting every one individually on our WCA OAuth application.