### PR TITLE
Move the non-live warning into components.

### DIFF
--- a/src/handlers/scheduling/event_display.py
+++ b/src/handlers/scheduling/event_display.py
@@ -20,5 +20,4 @@ class EventDisplayHandler(SchedulingBaseHandler):
         'c': common.Common(self),
         'competition': self.competition,
         'competition_details': CompetitionDetails(self.user, self.competition, schedule),
-        'not_live_warning': schedule_version != -1,
     }))

--- a/src/handlers/scheduling/schedule_display.py
+++ b/src/handlers/scheduling/schedule_display.py
@@ -24,5 +24,4 @@ class ScheduleDisplayHandler(SchedulingBaseHandler):
         'c': common.Common(self),
         'competition': self.competition,
         'competition_details': CompetitionDetails(self.user, self.competition, schedule),
-        'not_live_warning': schedule_version != -1,
     }))

--- a/src/templates/components/scheduling/event_list.html
+++ b/src/templates/components/scheduling/event_list.html
@@ -5,6 +5,11 @@
       The organizers of {{ competition_details.competition.name }} haven't published a schedule yet.  Check back here soon!
     </div>
   {% else %}
+    {% if not competition_details.schedule.is_live %}
+      <div class="alert alert-warning" role="alert">
+        <strong>Warning!</strong>  You are looking at a non-live version of the schedule.
+      </div>
+    {% endif %}
     {{ event_selector.event_selector(c, events=competition_details.GetWcaEvents()) }}
     <div class="event-list-container">
       <div class="event-list">

--- a/src/templates/components/scheduling/schedule.html
+++ b/src/templates/components/scheduling/schedule.html
@@ -4,6 +4,11 @@
       The organizers of {{ competition_details.competition.name }} haven't published a schedule yet.  Check back here soon!
     </div>
   {% else %}
+    {% if not competition_details.schedule.is_live %}
+      <div class="alert alert-warning" role="alert">
+        <strong>Warning!</strong>  You are looking at a non-live version of the schedule.
+      </div>
+    {% endif %}
     <div class="schedule-container">
       {% for day, time_blocks in competition_details.TimeBlocksByDay() %}
         <div class="day-container">

--- a/src/templates/scheduling/event_display.html
+++ b/src/templates/scheduling/event_display.html
@@ -8,11 +8,6 @@
 {% block content %}
   <div class="container">
     <h1>{{ competition.name }} Events</h1>
-    {% if not_live_warning %}
-      <div class="alert alert-warning" role="alert">
-        <strong>Warning!</strong>  You are looking at a non-live version of the schedule.
-      </div>
-    {% endif %}
     {{ event_list.event_list(c, competition_details) }}
   </div>
 {% endblock %}

--- a/src/templates/scheduling/schedule_display.html
+++ b/src/templates/scheduling/schedule_display.html
@@ -8,11 +8,6 @@
 {% block content %}
   <div class="container">
     <h1>{{ competition.name }} Schedule</h1>
-    {% if not_live_warning %}
-      <div class="alert alert-warning" role="alert">
-        <strong>Warning!</strong>  You are looking at a non-live version of the schedule.
-      </div>
-    {% endif %}
     {{ schedule.schedule(c, competition_details) }}
   </div>
 {% endblock %}


### PR DESCRIPTION
The schedule-editing page has links to view the schedule currently being edited.  Previously this always said it was not live, but now we check whether it's live or not.