### PR TITLE
Speed up the import of rankings.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -25,13 +25,13 @@ indexes:
   properties:
   - name: event
   - name: state
-  - name: worldRank
+  - name: best
 
 - kind: RankSingle
   properties:
   - name: event
   - name: state
-  - name: worldRank
+  - name: best
 
 - kind: Result
   properties:

--- a/src/handlers/async/state_rankings.py
+++ b/src/handlers/async/state_rankings.py
@@ -24,7 +24,7 @@ class StateRankingsHandler(BaseHandler):
     rankings = (ranking_class.query(
         ndb.AND(ranking_class.event == event.key,
                 ranking_class.state == state.key))
-        .order(ranking_class.worldRank)
+        .order(ranking_class.best)
         .fetch(100))
 
     people = ndb.get_multi([ranking.person for ranking in rankings])

--- a/src/models/wca/rank.py
+++ b/src/models/wca/rank.py
@@ -11,10 +11,6 @@ class RankBase(BaseModel):
   best = ndb.IntegerProperty()
   state = ndb.ComputedProperty(lambda self: self.GetState())
 
-  worldRank = ndb.IntegerProperty()
-  continentRank = ndb.IntegerProperty()
-  countryRank = ndb.IntegerProperty()
-
   def GetState(self):
     if not self.person or not self.person.get():
       return None
@@ -29,13 +25,9 @@ class RankBase(BaseModel):
     self.event = ndb.Key(Event, row['eventId'])
     self.best = int(row['best'])
 
-    self.worldRank = int(row['worldRank'])
-    self.continentRank = int(row['continentRank'])
-    self.countryRank = int(row['countryRank'])
-
   @staticmethod
   def ColumnsUsed():
-    return ['personId', 'eventId', 'best', 'worldRank', 'continentRank', 'countryRank']
+    return ['personId', 'eventId', 'best']
 
   def ObjectsToGet(self):
     return [self.person]


### PR DESCRIPTION
Don't store worldRank, continentRank, or countryRank.  These change for virtually all competitors every time there's a new competition, and the import process is much faster for rows that don't change.