### PR TITLE
Update the way regional champions are computed.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -89,4 +89,9 @@ indexes:
   properties:
   - name: user
   - name: update_time
+
+- kind: UserLocationUpdate
+  properties:
+  - name: user
+  - name: update_time
     direction: desc

--- a/src/auth.py
+++ b/src/auth.py
@@ -8,15 +8,7 @@ def CanEditLocation(user, editor):
     return False
   if editor.HasAnyRole(Roles.AdminRoles()):
     return True
-  if user == editor:
-    last_update = (UserLocationUpdate.query(UserLocationUpdate.user == user.key)
-                                     .order(-UserLocationUpdate.update_time)
-                                     .get())
-    if last_update and datetime.datetime.now() - last_update.update_time < datetime.timedelta(days=365):
-      return False
-    return True
-  else:
-    return False
+  return user == editor
 
 def CanViewUser(user, viewer):
   if not viewer:

--- a/src/models/eligibility.py
+++ b/src/models/eligibility.py
@@ -1,0 +1,25 @@
+from google.appengine.ext import ndb
+
+from src.models.region import Region
+from src.models.state import State
+from src.models.user import User
+
+
+class RegionalChampionshipEligibility(ndb.Model):
+  user = ndb.KeyProperty(kind=User)
+  year = ndb.IntegerProperty()
+  region = ndb.KeyProperty(kind=Region)
+
+  @staticmethod
+  def Id(user_id, year):
+    return '%s_%d' % (user_id, year)
+
+
+class StateChampionshipEligibility(ndb.Model):
+  user = ndb.KeyProperty(kind=User)
+  year = ndb.IntegerProperty()
+  state = ndb.KeyProperty(kind=State)
+
+  @staticmethod
+  def Id(user_id, year):
+    return '%s_%d' % (user_id, year)

--- a/src/post_import/mutations.py
+++ b/src/post_import/mutations.py
@@ -1,6 +1,4 @@
-from google.appengine.ext import deferred
-
 from src.post_import.update_champions import UpdateChampions
 
 def DoMutations():
-  deferred.defer(UpdateChampions)
+  UpdateChampions()

--- a/src/templates/edit_user.html
+++ b/src/templates/edit_user.html
@@ -80,7 +80,7 @@
         </div>
         <div class="about-city-selection">
           <small id="city-help" class="form-text text-muted">
-            City and state determine your eligibility for Regional Championships.  You may only represent a state where you live at least 50% of the year, and you may only change your information once per year.  We reserve the right to ask for proof of residency.  If you are not a US resident, or you would prefer not to list your home state, please select "N/A".
+            City and state determine your eligibility for Regional Championships.  You may only represent a state where you live at least 50% of the year.  We reserve the right to ask for proof of residency.  If you are not a US resident, or you would prefer not to list your home state, please select "N/A".
           </small>
         </div>
       </div>


### PR DESCRIPTION
Use competitors' residence, as of the first morning of the competition, to compute regional champions.

Create an "eligibility" entity for each competitor who was eligible for championships, and use these to make sure that no competitor is eligible for more than one championship of any type in any year.