### PR TITLE
Move UserLocationUpdate onto the User object.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -5,6 +5,7 @@ from src.handlers.admin.app_settings import AppSettingsHandler
 from src.handlers.admin.assign_role import AssignRoleHandler
 from src.handlers.admin.get_wca_export import GetExportHandler
 from src.handlers.admin.copy_user_states import CopyUserStatesHandler
+from src.handlers.admin.move_user_location_updates import MoveUserLocationUpdatesHandler
 from src.handlers.admin.post_import_mutations import PostImportMutationsHandler
 from src.handlers.admin.update_states import UpdateStatesHandler
 from src.handlers.admin.upload_users import UploadUsersHandler
@@ -31,4 +32,5 @@ app = webapp2.WSGIApplication([
   webapp2.Route('/wca/get_export', handler=GetExportHandler),
   webapp2.Route('/assign_role/<user_id:.*>/<role:.*>', handler=AssignRoleHandler),
   webapp2.Route('/app_settings', handler=AppSettingsHandler, name='app_settings'),
+  webapp2.Route('/move_user_location_updates', handler=MoveUserLocationUpdatesHandler),
 ], config=config.GetAppConfig())

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,7 +1,6 @@
 import datetime
 
 from src.models.user import Roles
-from src.models.user import UserLocationUpdate
 
 def CanEditLocation(user, editor):
   if not editor:

--- a/src/handlers/admin/move_user_location_updates.py
+++ b/src/handlers/admin/move_user_location_updates.py
@@ -1,0 +1,30 @@
+from google.appengine.ext import ndb
+
+from src.handlers.admin.admin_base import AdminBaseHandler
+
+from src.models.user import Roles
+from src.models.user import User
+from src.models.user import UserLocationUpdate
+
+class MoveUserLocationUpdatesHandler(AdminBaseHandler):
+  def get(self):
+    entities_to_put = []
+    entities_to_delete = []
+    users = {}
+    for user in User.query().iter():
+      users[user.key.id()] = user
+    for update in UserLocationUpdate.query().order(UserLocationUpdate.update_time).iter():
+      user = users[update.user.id()]
+      del update.user
+      if not user.updates:
+        user.updates = []
+      user.updates.append(update)
+      entities_to_delete.append(update.key)
+    for user in users.itervalues():
+      if user.updates:
+        entities_to_put.append(user)
+    ndb.delete_multi(entities_to_delete)
+    ndb.put_multi(entities_to_put)
+
+  def PermittedRoles(self):
+    return Roles.AdminRoles()

--- a/src/handlers/admin/upload_users.py
+++ b/src/handlers/admin/upload_users.py
@@ -76,13 +76,12 @@ class UploadUsersHandler(AdminBaseHandler):
       # Also make a back-dated UserLocationUpdate.  We make it in the past so
       # that the user can immediately modify their location on the new site.
       update = UserLocationUpdate()
-      update.user = user.key
       update.updater = user.key
       update.city = user.city
       update.state = user.state
       update.update_time = datetime.datetime(2016, 1, 1)
+      user.updates = [update]
       futures.append(user.put_async())
-      futures.append(update.put_async())
     for future in futures:
       future.wait()
 

--- a/src/handlers/edit_user.py
+++ b/src/handlers/edit_user.py
@@ -107,13 +107,14 @@ class EditUserHandler(BaseHandler):
       if changed_location:
         # Also save the Update.
         update = UserLocationUpdate()
-        update.user = user.key
         update.updater = self.user.key
-        update.city = city
+        if city:
+          update.city = city
         update.update_time = datetime.datetime.now()
         if state_id:
           update.state = ndb.Key(State, state_id)
-        update.put()
+        user.updates.append(update)
+
     elif changed_location:
       template_dict['unauthorized'] = True
 

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -24,6 +24,15 @@ class Roles:
   @staticmethod
   def AdminRoles():
     return [Roles.GLOBAL_ADMIN, Roles.DIRECTOR, Roles.WEBMASTER]
+ 
+
+class UserLocationUpdate(ndb.Model):
+  city = ndb.StringProperty()
+  state = ndb.KeyProperty(kind=State)
+
+  update_time = ndb.DateTimeProperty()
+  updater = ndb.KeyProperty(kind=User)
+
 
 class User(ndb.Model):
   wca_person = ndb.KeyProperty(kind=Person)
@@ -38,6 +47,8 @@ class User(ndb.Model):
   longitude = ndb.IntegerProperty()
 
   last_login = ndb.DateTimeProperty()
+
+  updates = ndb.StructuredProperty(kind=UserLocationUpdate, repeated=True)
 
   def HasAnyRole(self, roles):
     for role in self.roles:
@@ -78,12 +89,3 @@ class User(ndb.Model):
   def DeleteUser(self):
     User.GetSearchIndex().delete(str(self.key.id()))
     self.key.delete()
- 
-
-class UserLocationUpdate(ndb.Model):
-  city = ndb.StringProperty()
-  state = ndb.KeyProperty(kind=State)
-
-  update_time = ndb.DateTimeProperty()
-  user = ndb.KeyProperty(kind=User)
-  updater = ndb.KeyProperty(kind=User)

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -93,4 +93,6 @@ class User(ndb.Model):
 
 
 UserLocationUpdate.updater = ndb.KeyProperty(kind=User)
+# TODO: delete this field post-migration.
+UserLocationUpdate.user = ndb.KeyProperty(kind=User)
 UserLocationUpdate._fix_up_properties()

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -24,15 +24,16 @@ class Roles:
   @staticmethod
   def AdminRoles():
     return [Roles.GLOBAL_ADMIN, Roles.DIRECTOR, Roles.WEBMASTER]
- 
+
 
 class UserLocationUpdate(ndb.Model):
   city = ndb.StringProperty()
   state = ndb.KeyProperty(kind=State)
 
   update_time = ndb.DateTimeProperty()
-  updater = ndb.KeyProperty(kind=User)
-
+  # Defined at end of file (it's a circular reference so we can't define here)
+  # updater = ndb.KeyProperty(kind=User)
+ 
 
 class User(ndb.Model):
   wca_person = ndb.KeyProperty(kind=Person)
@@ -48,7 +49,7 @@ class User(ndb.Model):
 
   last_login = ndb.DateTimeProperty()
 
-  updates = ndb.StructuredProperty(kind=UserLocationUpdate, repeated=True)
+  updates = ndb.StructuredProperty(UserLocationUpdate, repeated=True)
 
   def HasAnyRole(self, roles):
     for role in self.roles:
@@ -89,3 +90,7 @@ class User(ndb.Model):
   def DeleteUser(self):
     User.GetSearchIndex().delete(str(self.key.id()))
     self.key.delete()
+
+
+UserLocationUpdate.updater = ndb.KeyProperty(kind=User)
+UserLocationUpdate._fix_up_properties()


### PR DESCRIPTION
Previously we stored UserLocationUpdate as a separate datastore entity to track down the order in which changes were made, so that we can check where competitors lived at the time of a championship.

With this change the updates are now stored as part of the User entity.  The same information is still kept.

This change adds a handler to migrate to the new format, and points all references at the new format.  Once the handler has been run, a second cleanup PR can be submitted.