### PR TITLE
Finally make google groups updater work

### DIFF
--- a/src/handlers/admin/app_settings.py
+++ b/src/handlers/admin/app_settings.py
@@ -27,7 +27,7 @@ class AppSettingsHandler(BaseHandler):
     settings.recaptcha_secret_key = self.request.POST['recaptcha_secret_key']
     settings.google_analytics_tracking_id = self.request.POST['google_analytics_tracking_id']
     settings.contact_email = self.request.POST['contact_email']
-    settings.service_account_credentials = self.request.POST['service_account_credentials']
+    settings.mailing_list_service_account_credentials = self.request.POST['mailing_list_service_account_credentials']
     settings.put()
     template = JINJA_ENVIRONMENT.get_template('admin/app_settings.html')
     self.response.write(template.render({

--- a/src/handlers/admin/app_settings.py
+++ b/src/handlers/admin/app_settings.py
@@ -27,6 +27,7 @@ class AppSettingsHandler(BaseHandler):
     settings.recaptcha_secret_key = self.request.POST['recaptcha_secret_key']
     settings.google_analytics_tracking_id = self.request.POST['google_analytics_tracking_id']
     settings.contact_email = self.request.POST['contact_email']
+    settings.service_account_credentials = self.request.POST['service_account_credentials']
     settings.put()
     template = JINJA_ENVIRONMENT.get_template('admin/app_settings.html')
     self.response.write(template.render({

--- a/src/handlers/admin/update_mailing_list.py
+++ b/src/handlers/admin/update_mailing_list.py
@@ -1,10 +1,8 @@
-import httplib2
 import json
 import logging
 import requests
 import urllib
 
-from google.appengine.api import memcache
 from google.appengine.api import urlfetch
 from google.oauth2 import service_account
 import googleapiclient.discovery

--- a/src/handlers/admin/update_mailing_list.py
+++ b/src/handlers/admin/update_mailing_list.py
@@ -1,13 +1,16 @@
+import httplib2
 import json
 import logging
 import requests
 import urllib
 
+from google.appengine.api import memcache
 from google.appengine.api import urlfetch
-from google.auth import app_engine
+from google.oauth2 import service_account
 import googleapiclient.discovery
 
 from src.handlers.admin.admin_base import AdminBaseHandler
+from src.models.app_settings import AppSettings
 from src.models.user import Roles
 from src.models.user import User
 from src.models.wca.person import Person
@@ -30,7 +33,10 @@ def clean_email(email):
 
 class UpdateMailingListHandler(AdminBaseHandler):
   def get(self):
-    credentials = app_engine.Credentials()
+    credentials = service_account.Credentials.from_service_account_info(
+                      json.loads(AppSettings.Get().mailing_list_service_account_credentials),
+                      scopes=['https://www.googleapis.com/auth/admin.directory.group.member'],
+                      subject='adminbot@cubingusa.org')
 
     service = googleapiclient.discovery.build('admin', 'directory_v1', credentials=credentials)
 

--- a/src/models/app_settings.py
+++ b/src/models/app_settings.py
@@ -11,6 +11,7 @@ class AppSettings(ndb.Model):
   recaptcha_secret_key = ndb.StringProperty()
   google_analytics_tracking_id = ndb.StringProperty()
   contact_email = ndb.StringProperty()
+  service_account_credentials = ndb.TextProperty()
 
   @staticmethod
   def Get():

--- a/src/models/app_settings.py
+++ b/src/models/app_settings.py
@@ -11,7 +11,7 @@ class AppSettings(ndb.Model):
   recaptcha_secret_key = ndb.StringProperty()
   google_analytics_tracking_id = ndb.StringProperty()
   contact_email = ndb.StringProperty()
-  service_account_credentials = ndb.TextProperty()
+  mailing_list_service_account_credentials = ndb.TextProperty()
 
   @staticmethod
   def Get():

--- a/src/templates/admin/app_settings.html
+++ b/src/templates/admin/app_settings.html
@@ -70,7 +70,13 @@ http://localhost:8081/oauth_callback
     <input type="email" name="contact_email" value="{{ settings.contact_email or ''}}">
     <div>
       (Not used for dev) Email to send and receive contact form submissions.  When run locally, uses your email address.
-    </div>  
+    </div>
+    <h3>Service Account Credentials</h3>
+    <p>
+      <textarea name="service_account_credentials" rows="12" cols="50">
+        {{ settings.service_account_credentials }}
+      </textarea>
+    </p>
     <button type="submit">Submit</button>
   </form>
 </body>

--- a/src/templates/admin/app_settings.html
+++ b/src/templates/admin/app_settings.html
@@ -71,11 +71,10 @@ http://localhost:8081/oauth_callback
     <div>
       (Not used for dev) Email to send and receive contact form submissions.  When run locally, uses your email address.
     </div>
-    <h3>Service Account Credentials</h3>
+    <h3>Mailing List Updater Credentials</h3>
     <p>
-      <textarea name="service_account_credentials" rows="12" cols="50">
-        {{ settings.service_account_credentials }}
-      </textarea>
+      <textarea name="mailing_list_service_account_credentials" rows="12" cols="50">{{ settings.mailing_list_service_account_credentials }}</textarea>
+      <div>(Optional) Credentials for service account to update mailing lists on cubingusa.org.</div>
     </p>
     <button type="submit">Submit</button>
   </form>


### PR DESCRIPTION
Use a non-default service account (c.f. https://stackoverflow.com/questions/32439156/google-application-default-credentials-insufficient-permission-in-developmen "I do not think that Application Default Credentials supports domain-wide delegation of authority") and use that account to impersonate adminbot.