### PR TITLE
Competition-day info for Nationals

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -6,6 +6,9 @@
 {% endblock %}
 {% block content %}
   <div class="container">
+  <div class="alert alert-info" role="alert">
+    <strong>This weekend is CubingUSA Nationals in Salt Lake City, Utah!</strong>  Head over to the <a href="/nationals">Nationals page</a> for the schedule, streaming, results, and more.
+  </div>
   <p>
   <div class="card" id="main-card">
     <figure>

--- a/src/templates/nationals/2018/index.html
+++ b/src/templates/nationals/2018/index.html
@@ -6,6 +6,7 @@
   {{ css.css(c, 'nationals/2018/index') }}
 {% endblock %}
 {% block content %}
+  <iframe src="https://embed.twitch.tv?channel=mentalblocktv&amp;theme=dark" allowfullscreen="" scrolling="no" frameborder="0" allow="autoplay; fullscreen" width="100%" height="500px"></iframe>
   <div class="nats-top-row">
     <div class="top-info">
       <h2 class="d-none d-xs-block">CubingUSA Nationals 2018</h2>


### PR DESCRIPTION
To be merged on Thursday.

Embed the live stream on the nationals page.  Add a link to the top of cubingusa.org pointing to the nationals page.