### PR TITLE
Change the year in the footer

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -11,6 +11,9 @@ from src.models.wca.event import Event
 from src.models.wca.export import get_latest_export
 
 class Common(object):
+  
+  currentDate = datetime.datetime.now()
+  
   def __init__(self, handler):
     self.uri_for = webapp2.uri_for
     self.uri = handler.request.url

--- a/src/common.py
+++ b/src/common.py
@@ -12,7 +12,7 @@ from src.models.wca.export import get_latest_export
 
 class Common(object):
   
-  currentDate = datetime.datetime.now()
+  current_date = datetime.datetime.now()
   
   def __init__(self, handler):
     self.uri_for = webapp2.uri_for

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -88,7 +88,7 @@
   <hr>
   <div class="container">
     <footer>
-      © CubingUSA {% print(c.currentDate.year) %}.
+      © CubingUSA {{ c.currentDate.year }}.
       {% if c.include_wca_disclaimer %}
         Results, competition listings, and rankings shown on this page come from the <a href="https://www.worldcubeassociation.org">World Cube Association</a>, who are the source and owner of this information.  The actual information from which this page is derived can be found on the <a href="https://www.worldcubeassociation.org/results">WCA results page</a>.  This page uses the WCA export from {{ c.get_wca_export() }}.
       {% endif %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -88,7 +88,7 @@
   <hr>
   <div class="container">
     <footer>
-      © CubingUSA {{ c.currentDate.year }}.
+      © CubingUSA {{ c.current_date.year }}.
       {% if c.include_wca_disclaimer %}
         Results, competition listings, and rankings shown on this page come from the <a href="https://www.worldcubeassociation.org">World Cube Association</a>, who are the source and owner of this information.  The actual information from which this page is derived can be found on the <a href="https://www.worldcubeassociation.org/results">WCA results page</a>.  This page uses the WCA export from {{ c.get_wca_export() }}.
       {% endif %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -88,7 +88,7 @@
   <hr>
   <div class="container">
     <footer>
-      © CubingUSA 2017.
+      © CubingUSA {% print(c.currentDate.year) %}.
       {% if c.include_wca_disclaimer %}
         Results, competition listings, and rankings shown on this page come from the <a href="https://www.worldcubeassociation.org">World Cube Association</a>, who are the source and owner of this information.  The actual information from which this page is derived can be found on the <a href="https://www.worldcubeassociation.org/results">WCA results page</a>.  This page uses the WCA export from {{ c.get_wca_export() }}.
       {% endif %}


### PR DESCRIPTION
Makes the year in the footer of pages the current year, rather than having to change it each time.