### PR TITLE
Link supported comps page to new organizer site

### DIFF
--- a/src/templates/supported.html
+++ b/src/templates/supported.html
@@ -6,53 +6,14 @@
     <h1>CubingUSA Supported Competitions</h1>
     <div>
       <p>
-        CubingUSA Supported Competitions are an <b>optional</b> way to run a competition under the auspices of CubingUSA, which means that all finances fall under the domain of CubingUSA. Organizers can still independently run a WCA-recognized competition by following WCA regulations. 
+        Most WCA-recognized competitions in the US are run independently by local organizers with no involvement from CubingUSA.
       </p>
-      <h3>Benefits Highlights</h3>
-      <ul>
-        <li>All income and expences are in the name of CubingUSA, avoiding impact on organizers' personal finances.</li>
-        <li>Venues and other services may be negotiated in the name of CubingUSA, a registered 501(c)(3) non-profit organization, which may be financially preferable.</li>
-        <li>CubingUSA can cover event insurance if required by the venue.</li>
-      </ul>
-      <h3>Requirements Highlights</h3>
       <p>
-        In order to ensure financial accountability, organizers must follow policies which include:
+        CubingUSA Supported Competitions are an <b>optional</b> way for US organizers to run a competition under the auspices of CubingUSA, which means that all finances fall under the domain of CubingUSA.
       </p>
-      <ul>
-        <li>Organizers must submit an application including an estimated budget at least <b>60 days in advance</b>.</li>
-        <li>Any net income goes into the CubingUSA general fund.</li>
-        <li>Organizers must agree to the CubingUSA Code of Conduct as seen on the <a href="{{ c.uri_for('documents') }}">Documents</a> page.</li>
-        <li>Notably, organizers may not personally financially benefit and must report any potential conflicts of interest.</li>
-        <li>Expenses must be pre-approved and may only be re-imbursed with receipts.</li>
-        <li>Expenses that were not pre-approved may be rejected at CubingUSA's discretion.</li>
-        <li>All sponsorships, partnerships, and prizes must be pre-approved.</li>
-        <li>A CubingUSA Deputy, appointed by the CubingUSA Board of Directors, must be involved in the organization of the competition and must be present at the competition to ensure relevant policies are followed. (CubingUSA Deputies may or may not also be an organizer or WCA Delegate.)</li>
-        <li>A Financial Report must be submitted after the competition.</li>
-      </ul>
-      <h3>Full Policy</h3>
       <p>
-        The full Supported Competitions Policy is available on our <a href="{{ c.uri_for('documents') }}">Documents</a> page.
+        Organizers, please visit the <a href="https://organizers.cubingusa.org/">CubingUSA Organizer Policies</a> site for details.
       </p>
-      <h3>More Information</h3>
-      <p>
-        If you are interested in organizing a CubingUSA Supported Competition, please use our <a href="{{ c.uri_for('contact') }}">contact page</a> for more information.
-      </p>
-      <h3>How to file an expense reimbursement request</h3>
-      <p>
-        Send an email to the CubingUSA Treasurer with the following information:
-        <ul>
-          <li>Competition name</li>
-          <li>Your name</li>
-          <li>Date of expense</li>
-          <li>Amount</li>
-          <li>Type and description</li>
-          <li><b>Attached copy of receipt</b> (Forwarded emails, screenshots, and mobile phone photos are fine.)</li>
-          <li>Check mailing address or PayPal email address</li>
-          <li><b>Please note if an exception to the approved budget is being requested.</b></li>
-        </ul>
-      </p>
-      <p>Organizers may aggregate several expenses into a single request (with appropriate breakdown).</p>
-      <p>Expenses must be filed within 30 days of when the charge was incurred.</p>
     </div>
   </div>
 {% endblock %}

--- a/src/templates/supported.html
+++ b/src/templates/supported.html
@@ -9,7 +9,7 @@
         Most WCA-recognized competitions in the US are run independently by local organizers with no involvement from CubingUSA.
       </p>
       <p>
-        CubingUSA Supported Competitions are an <b>optional</b> way for US organizers to run a competition under the auspices of CubingUSA, which means that all finances fall under the domain of CubingUSA.
+        CubingUSA Supported Competitions are an <strong>optional</strong> way for US organizers to run a competition under the auspices of CubingUSA, which means that all finances fall under the domain of CubingUSA.
       </p>
       <p>
         Organizers, please visit the <a href="https://organizers.cubingusa.org/">CubingUSA Organizer Policies</a> site for details.


### PR DESCRIPTION
Replace contents of supported comps site with link to new Organizer Policies Sites page.