### PR TITLE
Update regional champions year

### DIFF
--- a/src/static/js/regionals.js
+++ b/src/static/js/regionals.js
@@ -17,7 +17,7 @@ var regionalsModule = (function() {
           }
         }
       };
-      var uri = '/async/champions_by_region/' + event_id + '/regional/2018';
+      var uri = '/async/champions_by_region/' + event_id + '/regional/2019';
       req.open('GET', uri);
       req.send();
     },


### PR DESCRIPTION
Trying to fix #230 

It'd be better to not have to update this each year, but the current year can't just be inserted. Is there an easy way to check if the current year's championships have already happened?