### PR TITLE
Update the text on the home page about Nationals.

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
           <a href="/nationals"><img class="card-img-top" src="/static/img/nats-logo-2019-full-1024.png" alt="CubingUSA Nationals 2019"></a>
           <div class="card-body">
             <h4 class="card-title">CubingUSA Nationals</h4>
-            <p class="card-text">We're pleased to announce that Rubik's Presents CubingUSA Nationals 2019 will be held <b>August 1-4, 2019</b> in <b>Baltimore, Maryland!</b></p>
+            <p class="card-text">Rubik's Presents CubingUSA Nationals 2019 was held August 1-4, 2019 in Baltimore, Maryland.  Stay tuned for announcements about future Nationals!</p>
             <a href="/nationals" class="button">Learn More</a>
           </div>
         </div>


### PR DESCRIPTION
It referred to Nationals 2019 as though it's in the future, which it's not anymore.

Fixes #181