### PR TITLE
Datastore cleanup

### DIFF
--- a/app/lib/common.py
+++ b/app/lib/common.py
@@ -128,7 +128,7 @@ class Common(object):
     return secrets.get_secret(name)
 
   def get_wca_export(self):
-    val = get_latest_export().key.id()
+    val = get_latest_export()
     date_part = val.split('_')[-1][:8]
     return datetime.datetime.strptime(date_part, '%Y%m%d').strftime('%B %d, %Y').replace(' 0', ' ')
 

--- a/app/load_db/cleanup.py
+++ b/app/load_db/cleanup.py
@@ -1,0 +1,23 @@
+from google.cloud import ndb
+
+from app.models.wca.export import get_latest_export
+
+client = ndb.Client()
+
+# Delete classes we don't use anymore.
+with client.context():
+  for clsname in ['AppSettings',
+                  'Document',
+                  'Schedule',
+                  'ScheduleCompetition',
+                  'SchedulePerson',
+                  'ScheduleRound',
+                  'ScheduleStaff',
+                  'ScheduleStage',
+                  'ScheduleTimeBlock',
+                  'WcaExport']:
+    class MyModel(ndb.Model):
+      pass
+
+    MyModel.__name__ = clsname
+    ndb.delete_multi(MyModel.query().fetch(keys_only=True))

--- a/app/load_db/get_latest_export.py
+++ b/app/load_db/get_latest_export.py
@@ -7,4 +7,4 @@ client = ndb.Client()
 with client.context():
   export = get_latest_export()
   if export:
-    print(export.key.id())
+    print(export)

--- a/app/load_db/load_db.py
+++ b/app/load_db/load_db.py
@@ -11,7 +11,6 @@ from app.models.wca.competition import Competition
 from app.models.wca.continent import Continent
 from app.models.wca.country import Country
 from app.models.wca.event import Event
-from app.models.wca.export import WcaExport
 from app.models.wca.export import set_latest_export
 from app.models.wca.format import Format
 from app.models.wca.person import Person

--- a/app/models/wca/country.py
+++ b/app/models/wca/country.py
@@ -2,14 +2,11 @@ from google.cloud import ndb
 
 from app.models.wca.base import BaseModel
 from app.models.wca.continent import Continent
-from app.models.wca.export import WcaExport
 
 class Country(BaseModel):
   name = ndb.StringProperty()
   continent = ndb.KeyProperty(kind=Continent)
   iso2 = ndb.StringProperty()
-
-  export = ndb.KeyProperty(kind=WcaExport)
 
   def ParseFromDict(self, row):
     self.name = row['name']

--- a/app/models/wca/export.py
+++ b/app/models/wca/export.py
@@ -1,22 +1,15 @@
 from google.cloud import ndb
 
-class WcaExport(ndb.Model):
-  pass
-
 class LatestWcaExport(ndb.Model):
-  export = ndb.KeyProperty(kind=WcaExport)
+  export_id = ndb.StringProperty()
 
 def get_latest_export():
   latest = LatestWcaExport.get_by_id('1')
   if latest:
-    return latest.export.get()
+    return latest.export_id
   return None
 
 def set_latest_export(export_id):
   latest = LatestWcaExport.get_by_id('1') or LatestWcaExport(id='1')
-  if latest.export:
-    latest.export.delete()
-  latest.export = ndb.Key(WcaExport, export_id)
+  latest.export_id = export_id
   latest.put()
-  new_export = WcaExport(id=export_id)
-  new_export.put()


### PR DESCRIPTION
Clean up some old datastore things:
-Drop WcaExport model, which isn't needed.  Just store the ID in LatestWcaExport.
-Add a script to delete entities that we've stopped using.