### PR TITLE
Fix indentation in DB load code.

### DIFF
--- a/app/load_db/load_db.py
+++ b/app/load_db/load_db.py
@@ -49,10 +49,10 @@ def get_modifier(table):
       if user.wca_person:
         id_to_state[user.wca_person.id()] = user.state
 
-      def modify(person):
-        if person.key.id() in id_to_state:
-          person.state = id_to_state[person.key.id()]
-      return modify
+    def modify(person):
+      if person.key.id() in id_to_state:
+        person.state = id_to_state[person.key.id()]
+    return modify
   return None
 
 


### PR DESCRIPTION
As written, we only load the state of one arbitrary user and store it in Persons. This usually doesn't matter, but after creating a fresh VM, we overwrite the entire WCA datastore since we don't have the previous copy of the WCA DB. So this wiped out all of the state rankings, by not copying state from User to Person (and then to RankSingle / RankAverage).