### PR TITLE
DB load performance improvements

### DIFF
--- a/app/load_db/delete_old_exports.py
+++ b/app/load_db/delete_old_exports.py
@@ -1,0 +1,24 @@
+import shutil
+import os
+
+from absl import app
+from absl import flags
+from google.cloud import ndb
+
+from app.models.wca.export import get_latest_export
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('export_base', '', 'Base directory of exports.')
+
+client = ndb.Client()
+
+def main(argv):
+  with client.context():
+    latest_export = get_latest_export()
+    exports = sorted([f for f in os.listdir(FLAGS.export_base)
+                      if os.path.isfile(os.path.join(FLAGS.export_base, f))
+                      and f != latest_export])
+
+    for export in exports[:-2]:
+      shutil.rmtree(os.path.join(FLAGS.export_base, export))

--- a/app/load_db/load_db.py
+++ b/app/load_db/load_db.py
@@ -129,7 +129,7 @@ def process_export(old_export_path, new_export_path):
 
     logging.info('Putting %d objects' % len(objects_to_put))
     while objects_to_put:
-      batch_size = 500
+      batch_size = 5000
       logging.info('%d left' % len(objects_to_put))
       subslice = objects_to_put[:batch_size]
       objects_to_put = objects_to_put[batch_size:]

--- a/app/load_db/load_db.py
+++ b/app/load_db/load_db.py
@@ -100,16 +100,16 @@ def process_export(old_export_path, new_export_path):
   for table, cls in get_tables():
     logging.info('Processing ' + table)
     table_suffix = '/WCA_export_' + table + '.tsv'
-    old_rows = read_table(old_export_path + table_suffix, cls, False)
-    new_rows = read_table(new_export_path + table_suffix, cls, True)
-    logging.info('Old: %d' % len(old_rows))
-    logging.info('New: %d' % len(new_rows))
-    write_table(new_export_path + table_suffix, new_rows, cls)
-
-    objects_to_put = []
-    keys_to_delete = []
-
     with client.context():
+      old_rows = read_table(old_export_path + table_suffix, cls, False)
+      new_rows = read_table(new_export_path + table_suffix, cls, True)
+      logging.info('Old: %d' % len(old_rows))
+      logging.info('New: %d' % len(new_rows))
+      write_table(new_export_path + table_suffix, new_rows, cls)
+
+      objects_to_put = []
+      keys_to_delete = []
+
       modifier = get_modifier(table)
       for key in new_rows:
         row = new_rows[key]

--- a/app/load_db/load_db.sh
+++ b/app/load_db/load_db.sh
@@ -36,4 +36,7 @@ then
       --old_export_id="$SAVED_EXPORT" \
       --new_export_id="$LATEST_EXPORT" \
       --export_base=exports/
+
+  python3 app/load_db/delete_old_exports.py \
+      --export_base=exports/
 fi


### PR DESCRIPTION
A few changes to get the DB load working properly again:

- Delete old exports, which fill up the disk quite quickly.
- Use client contexts that are more tightly scoped, since they seem to leak memory.
- Use larger batches, and add logging.