### PR TITLE
Changes to contact form:

### DIFF
--- a/app/static/js/contact.js
+++ b/app/static/js/contact.js
@@ -6,7 +6,7 @@ onloadModule.register(function() {
       document.getElementById('noid-container').style.display = 'none';
       document.getElementById('name').disabled = false;
       document.getElementById('from-address').disabled = false;
-      document.getElementById('wcaid').disabled = false;
+      document.getElementById('wcaid-container').style.display = 'none';
       document.getElementById('contact-message').disabled = false;
       document.getElementById('send-button').disabled = false;
     }

--- a/app/templates/components/contact.html
+++ b/app/templates/components/contact.html
@@ -57,7 +57,7 @@
                    required>
           </div>
         </div>
-        <div class="contact-from-col">
+        <div class="contact-from-col" id="wcaid-container">
           <div class="form-group">
             <label for="wcaid">WCA ID</label>
             <input type="text"


### PR DESCRIPTION
- Only use WCA ID for logged-in users.
- Explicitly say at the bottom whether someone is logged-in or not.
- For logged-in users, use info from their account rather than the form, which can be spoofed.